### PR TITLE
Change tweet post

### DIFF
--- a/tweetstore_swagger.yaml
+++ b/tweetstore_swagger.yaml
@@ -88,15 +88,17 @@ paths:
     post:
       tags: 
       - "Module Twitter support"
-      summary: "Store a tweet in the TwitterStore"
-      description: "Stores a single tweet in the store"
+      summary: "Store a tweet(s) in the TwitterStore"
+      description: "Takes an array of Tweet objects to be stored in the database"
       requestBody:
-        description: "A tweet to be stored in the db"
+        description: "An array of Tweet objects"
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Tweet"
+              type: "array"
+              items:
+                $ref: "#/components/schemas/Tweet"
       responses:
         200:
           description: "The tweet was successfully stored in the database"

--- a/tweetstore_swagger.yaml
+++ b/tweetstore_swagger.yaml
@@ -128,17 +128,11 @@ components:
           description: "An array of objects holding a shortened and an expanded url"
           type: "array"
           items:
-            $ref: "#/component/schemas/Urls"
-          example:
-            - expandend_url: "https://www.youtube.com/watch?v=zlJDTxahav0"
-            - short_url: "https://youtu.be/zlJDTxahav0"
-    Urls:
-      type: "object"
-      properties:
-        expanded_url:
-          type: "string"
-          example: "https://www.youtube.com/watch?v=zlJDTxahav0"
-        short_url:
-          type: "string"
-          example: "https://youtu.be/zlJDTxahav0"
-
+            type: "object"
+            properties:
+              expanded_url:
+                type: "string"
+                example: "https://www.youtube.com/watch?v=zlJDTxahav0"
+              short_url:
+                type: "string"
+                example: "https://youtu.be/zlJDTxahav0"

--- a/tweetstore_swagger.yaml
+++ b/tweetstore_swagger.yaml
@@ -124,3 +124,18 @@ components:
             type: "integer"
             format: "int64"
           example: [1, 2, 3, 4]
+        urls:
+          description: "Annar array of objects holding a shortened and an expanded url"
+          type: "array"
+          items:
+            $ref: "#/component/schemas/Urls"
+    Urls:
+      type: "object"
+      properties:
+        expanded_url:
+          type: "string"
+          example: "https://www.youtube.com/watch?v=zlJDTxahav0"
+        short_url:
+          type: "string"
+          example: "https://youtu.be/zlJDTxahav0"
+

--- a/tweetstore_swagger.yaml
+++ b/tweetstore_swagger.yaml
@@ -13,7 +13,7 @@ paths:
     get:
       tags: 
       - "Module Twitter support" 
-      summary: "Get a previously retreived Tweet"
+      summary: "Get a Tweet previously retreived from Twitter by a module and stored in the database by that module"
       parameters:
       - name: "tweet_id"
         in: "path"
@@ -29,7 +29,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Tweet"
         404:
-          description: "Resoruce not found, it does not exist in our database"
+          description: "Resource not found, it does not exist in our database"
   /tweet/{tweet_id}/replies:
     get:
       tags:
@@ -125,7 +125,7 @@ components:
             format: "int64"
           example: [1, 2, 3, 4]
         urls:
-          description: "An array of objects holding a shortened and an expanded url"
+          description: "An array of objects where each object holds a shortened and an expanded url cotained in the tweet"
           type: "array"
           items:
             type: "object"

--- a/tweetstore_swagger.yaml
+++ b/tweetstore_swagger.yaml
@@ -125,10 +125,13 @@ components:
             format: "int64"
           example: [1, 2, 3, 4]
         urls:
-          description: "Annar array of objects holding a shortened and an expanded url"
+          description: "An array of objects holding a shortened and an expanded url"
           type: "array"
           items:
             $ref: "#/component/schemas/Urls"
+          example:
+            - expandend_url: "https://www.youtube.com/watch?v=zlJDTxahav0"
+            - short_url: "https://youtu.be/zlJDTxahav0"
     Urls:
       type: "object"
       properties:


### PR DESCRIPTION
Proposal to change the TweetStore API to accept an array of Tweet objects instead of a single Tweet object in the POST request. I think this reflects better the behaviour for the modules. When fetching/scraping Twitter for tweets to store in the database, instead of having to make one POST request / Tweet that should be stored in the database the server can take an array of tweetobjects in the request body to be stored in the database.

Should reduce number of request made and hence load on the api.